### PR TITLE
Make SqlQuery cancel asnyc, and add a cancel timout, which upon firing actively destroys the database connection to un-block the original thread.

### DIFF
--- a/src/main/scala/com/twitter/querulous/ConnectionDestroying.scala
+++ b/src/main/scala/com/twitter/querulous/ConnectionDestroying.scala
@@ -1,0 +1,42 @@
+package com.twitter.querulous.query
+
+import java.sql.Connection
+import org.apache.commons.dbcp.{DelegatingConnection => DBCPConnection}
+import com.mysql.jdbc.{ConnectionImpl => MySQLConnection}
+
+
+// Emergency connection destruction toolkit
+
+trait ConnectionDestroying {
+  def destroyConnection(conn: Connection) {
+    if ( !conn.isClosed )
+      conn match {
+        case c: DBCPConnection =>
+          destroyDbcpWrappedConnection(c)
+        case c: MySQLConnection =>
+          destroyMysqlConnection(c)
+        case _ => error("Unsupported driver type, cannot reliably timeout.")
+      }
+  }
+
+  def destroyDbcpWrappedConnection(conn: DBCPConnection) {
+    val inner = conn.getInnermostDelegate
+
+    if ( inner != null ) {
+      destroyConnection(inner)
+    } else {
+      // this should never happen if we use our own ApachePoolingDatabase to get connections.
+      error("Could not get access to the delegate connection. Make sure the dbcp connection pool allows access to underlying connections.")
+    }
+
+    // "close" the wrapper so that it updates its internal bookkeeping, just do it
+    try { conn.close } catch { case _ => }
+  }
+
+  def destroyMysqlConnection(conn: MySQLConnection) {
+    val abort = Class.forName("com.mysql.jdbc.ConnectionImpl").getDeclaredMethod("abortInternal")
+    abort.setAccessible(true)
+
+    abort.invoke(conn)
+  }
+}

--- a/src/main/scala/com/twitter/querulous/database/ApachePoolingDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/ApachePoolingDatabase.scala
@@ -66,6 +66,7 @@ class ApachePoolingDatabase(
     false,
     true)
   private val poolingDataSource = new PoolingDataSource(connectionPool)
+  poolingDataSource.setAccessToUnderlyingConnectionAllowed(true)
 
   def close(connection: Connection) {
     try {

--- a/src/main/scala/com/twitter/querulous/query/SqlQuery.scala
+++ b/src/main/scala/com/twitter/querulous/query/SqlQuery.scala
@@ -74,11 +74,6 @@ class SqlQuery(connection: Connection, query: String, params: Any*) extends Quer
   }
 
   def cancel() {
-    cancelAsynchronously().await()
-  }
-
-  def cancelAsynchronously() = {
-    val cancelLatch = new java.util.concurrent.CountDownLatch(1)
     val cancelThread = new Thread("SQL query cancellation") {
       override def run() {
         try {
@@ -94,11 +89,9 @@ class SqlQuery(connection: Connection, query: String, params: Any*) extends Quer
             clobberConnection(connection)
           }
         } catch { case e: TimeoutException => }
-        cancelLatch.countDown()
       }
     }
     cancelThread.start()
-    cancelLatch
   }
 
   private def withStatement[A](f: => A) = {

--- a/src/main/scala/com/twitter/querulous/query/SqlQuery.scala
+++ b/src/main/scala/com/twitter/querulous/query/SqlQuery.scala
@@ -43,7 +43,7 @@ object NullValues {
 }
 
 private object QueryCancellation {
-  val cancelTimer = new java.util.Timer("Query cancellation timer", true)
+  val cancelTimer = new java.util.Timer("global query cancellation timer", true)
 }
 
 class SqlQuery(connection: Connection, query: String, params: Any*) extends Query {
@@ -74,7 +74,7 @@ class SqlQuery(connection: Connection, query: String, params: Any*) extends Quer
   }
 
   def cancel() {
-    val cancelThread = new Thread("SQL query cancellation") {
+    val cancelThread = new Thread("query cancellation") {
       override def run() {
         try {
           // FIXME make duration configurable


### PR DESCRIPTION
Name says it all, though I'm not sure how to automatically test this behavior. Manually tested and confirmed that this works.
