### PR TITLE
add url options as a connection creation parameter everywhere. add autoDisablingDatabase

### DIFF
--- a/config/test.conf
+++ b/config/test.conf
@@ -2,7 +2,7 @@ db {
   hostname = "localhost"
   username = "root"
   password = ""
-  url_options = {
+  url_options {
     useUnicode = "true"
     characterEncoding = "UTF-8"
   }

--- a/config/test.conf
+++ b/config/test.conf
@@ -1,4 +1,5 @@
 db {
   username = "root"
   password = ""
+  url_options = "useUnicode=true&characterEncoding=UTF-8"
 }

--- a/config/test.conf
+++ b/config/test.conf
@@ -1,5 +1,9 @@
 db {
+  hostname = "localhost"
   username = "root"
   password = ""
-  url_options = "useUnicode=true&characterEncoding=UTF-8"
+  url_options = {
+    useUnicode = "true"
+    characterEncoding = "UTF-8"
+  }
 }

--- a/src/main/scala/com/twitter/querulous/AutoDisabler.scala
+++ b/src/main/scala/com/twitter/querulous/AutoDisabler.scala
@@ -12,13 +12,15 @@ trait AutoDisabler {
   private var disabledUntil: Time = Time.never
   private var consecutiveErrors = 0
 
-  protected def throwIfDisabled() {
+  protected def throwIfDisabled(throwMessage: String): Unit = {
     synchronized {
       if (Time.now < disabledUntil) {
-        throw new SQLException("Server is temporarily disabled")
+        throw new SQLException("Server is temporarily disabled: " + throwMessage)
       }
     }
   }
+
+  protected def throwIfDisabled(): Unit = { throwIfDisabled("") }
 
   protected def noteOperationOutcome(success: Boolean) {
     synchronized {

--- a/src/main/scala/com/twitter/querulous/AutoDisabler.scala
+++ b/src/main/scala/com/twitter/querulous/AutoDisabler.scala
@@ -1,0 +1,35 @@
+package com.twitter.querulous
+
+import com.twitter.xrayspecs.{Time, Duration}
+import com.twitter.xrayspecs.TimeConversions._
+import java.sql.{SQLException, SQLIntegrityConstraintViolationException}
+
+
+trait AutoDisabler {
+  protected val disableErrorCount: Int
+  protected val disableDuration: Duration
+
+  private var disabledUntil: Time = Time.never
+  private var consecutiveErrors = 0
+
+  protected def throwIfDisabled() {
+    synchronized {
+      if (Time.now < disabledUntil) {
+        throw new SQLException("Server is temporarily disabled")
+      }
+    }
+  }
+
+  protected def noteOperationOutcome(success: Boolean) {
+    synchronized {
+      if (success) {
+        consecutiveErrors = 0
+      } else {
+        consecutiveErrors += 1
+        if (consecutiveErrors >= disableErrorCount) {
+          disabledUntil = disableDuration.fromNow
+        }
+      }
+    }
+  }
+}

--- a/src/main/scala/com/twitter/querulous/database/ApachePoolingDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/ApachePoolingDatabase.scala
@@ -52,7 +52,7 @@ class ApachePoolingDatabase(
   config.maxWait = maxWaitForConnectionReservation.inMillis
 
   config.timeBetweenEvictionRunsMillis = checkConnectionHealthWhenIdleFor.inMillis
-  config.testWhileIdle = true
+  config.testWhileIdle = false
   config.testOnBorrow = checkConnectionHealthOnReservation
   config.minEvictableIdleTimeMillis = evictConnectionIfIdleFor.inMillis
 

--- a/src/main/scala/com/twitter/querulous/database/ApachePoolingDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/ApachePoolingDatabase.scala
@@ -13,7 +13,7 @@ class ApachePoolingDatabaseFactory(
   checkConnectionHealthOnReservation: Boolean,
   evictConnectionIfIdleFor: Duration) extends DatabaseFactory {
 
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = {
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: Map[String, String]) = {
     val pool = new ApachePoolingDatabase(
       dbhosts,
       dbname,
@@ -35,7 +35,7 @@ class ApachePoolingDatabase(
   dbname: String,
   username: String,
   password: String,
-  urlOptions: String,
+  urlOptions: Map[String, String],
   minOpenConnections: Int,
   maxOpenConnections: Int,
   checkConnectionHealthWhenIdleFor: Duration,

--- a/src/main/scala/com/twitter/querulous/database/ApachePoolingDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/ApachePoolingDatabase.scala
@@ -13,12 +13,13 @@ class ApachePoolingDatabaseFactory(
   checkConnectionHealthOnReservation: Boolean,
   evictConnectionIfIdleFor: Duration) extends DatabaseFactory {
 
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String) = {
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = {
     val pool = new ApachePoolingDatabase(
       dbhosts,
       dbname,
       username,
       password,
+      urlOptions,
       minOpenConnections,
       maxOpenConnections,
       checkConnectionHealthWhenIdleFor,
@@ -27,8 +28,6 @@ class ApachePoolingDatabaseFactory(
       evictConnectionIfIdleFor)
     pool
   }
-
-  def apply(dbhosts: List[String], username: String, password: String) = apply(dbhosts, null, username, password)
 }
 
 class ApachePoolingDatabase(
@@ -36,6 +35,7 @@ class ApachePoolingDatabase(
   dbname: String,
   username: String,
   password: String,
+  urlOptions: String,
   minOpenConnections: Int,
   maxOpenConnections: Int,
   checkConnectionHealthWhenIdleFor: Duration,
@@ -57,7 +57,7 @@ class ApachePoolingDatabase(
   config.minEvictableIdleTimeMillis = evictConnectionIfIdleFor.inMillis
 
   private val connectionPool = new GenericObjectPool(null, config)
-  private val connectionFactory = new DriverManagerConnectionFactory(url(dbhosts, dbname), username, password)
+  private val connectionFactory = new DriverManagerConnectionFactory(url(dbhosts, dbname, urlOptions), username, password)
   private val poolableConnectionFactory = new PoolableConnectionFactory(
     connectionFactory,
     connectionPool,

--- a/src/main/scala/com/twitter/querulous/database/AutoDisablingDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/AutoDisablingDatabase.scala
@@ -1,0 +1,35 @@
+package com.twitter.querulous.database
+
+import com.twitter.xrayspecs.Duration
+import com.twitter.xrayspecs.TimeConversions._
+import java.sql.{Connection, SQLException, SQLIntegrityConstraintViolationException}
+
+
+class AutoDisablingDatabaseFactory(databaseFactory: DatabaseFactory, disableErrorCount: Int, disableDuration: Duration) extends DatabaseFactory {
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String) = {
+    new AutoDisablingDatabase(databaseFactory(dbhosts, dbname, username, password), disableErrorCount, disableDuration)
+  }
+
+  def apply(dbhosts: List[String], username: String, password: String) = {
+    new AutoDisablingDatabase(databaseFactory(dbhosts, username, password), disableErrorCount, disableDuration)
+  }
+}
+
+class AutoDisablingDatabase(database: Database, protected val disableErrorCount: Int, protected val disableDuration: Duration) extends Database with AutoDisabler {
+  def open() = {
+    throwIfDisabled()
+    try {
+      val rv = database.open()
+      noteOperationOutcome(true)
+      rv
+    } catch {
+      case e: SQLException =>
+        noteOperationOutcome(false)
+        throw e
+      case e: Exception =>
+        throw e
+    }
+  }
+
+  def close(connection: Connection) { database.close(connection) }
+}

--- a/src/main/scala/com/twitter/querulous/database/AutoDisablingDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/AutoDisablingDatabase.scala
@@ -7,17 +7,17 @@ import java.sql.{Connection, SQLException, SQLIntegrityConstraintViolationExcept
 
 class AutoDisablingDatabaseFactory(databaseFactory: DatabaseFactory, disableErrorCount: Int, disableDuration: Duration) extends DatabaseFactory {
   def apply(dbhosts: List[String], dbname: String, username: String, password: String) = {
-    new AutoDisablingDatabase(databaseFactory(dbhosts, dbname, username, password), disableErrorCount, disableDuration)
+    new AutoDisablingDatabase(databaseFactory(dbhosts, dbname, username, password), dbhosts.first, disableErrorCount, disableDuration)
   }
 
   def apply(dbhosts: List[String], username: String, password: String) = {
-    new AutoDisablingDatabase(databaseFactory(dbhosts, username, password), disableErrorCount, disableDuration)
+    new AutoDisablingDatabase(databaseFactory(dbhosts, username, password), dbhosts.first, disableErrorCount, disableDuration)
   }
 }
 
-class AutoDisablingDatabase(database: Database, protected val disableErrorCount: Int, protected val disableDuration: Duration) extends Database with AutoDisabler {
+class AutoDisablingDatabase(database: Database, dbhost: String, protected val disableErrorCount: Int, protected val disableDuration: Duration) extends Database with AutoDisabler {
   def open() = {
-    throwIfDisabled()
+    throwIfDisabled(dbhost)
     try {
       val rv = database.open()
       noteOperationOutcome(true)

--- a/src/main/scala/com/twitter/querulous/database/AutoDisablingDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/AutoDisablingDatabase.scala
@@ -6,7 +6,7 @@ import java.sql.{Connection, SQLException, SQLIntegrityConstraintViolationExcept
 
 
 class AutoDisablingDatabaseFactory(databaseFactory: DatabaseFactory, disableErrorCount: Int, disableDuration: Duration) extends DatabaseFactory {
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = {
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: Map[String, String]) = {
     new AutoDisablingDatabase(
       databaseFactory(dbhosts, dbname, username, password, urlOptions),
       dbhosts.first,

--- a/src/main/scala/com/twitter/querulous/database/AutoDisablingDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/AutoDisablingDatabase.scala
@@ -6,12 +6,12 @@ import java.sql.{Connection, SQLException, SQLIntegrityConstraintViolationExcept
 
 
 class AutoDisablingDatabaseFactory(databaseFactory: DatabaseFactory, disableErrorCount: Int, disableDuration: Duration) extends DatabaseFactory {
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String) = {
-    new AutoDisablingDatabase(databaseFactory(dbhosts, dbname, username, password), dbhosts.first, disableErrorCount, disableDuration)
-  }
-
-  def apply(dbhosts: List[String], username: String, password: String) = {
-    new AutoDisablingDatabase(databaseFactory(dbhosts, username, password), dbhosts.first, disableErrorCount, disableDuration)
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = {
+    new AutoDisablingDatabase(
+      databaseFactory(dbhosts, dbname, username, password, urlOptions),
+      dbhosts.first,
+      disableErrorCount,
+      disableDuration)
   }
 }
 

--- a/src/main/scala/com/twitter/querulous/database/Database.scala
+++ b/src/main/scala/com/twitter/querulous/database/Database.scala
@@ -57,5 +57,5 @@ trait Database {
     "jdbc:mysql://" + dbhosts.mkString(",") + dbnameSegment + "?" + urlOptions
   }
 
-  def urlOptions = "useUnicode=true&characterEncoding=UTF-8"
+  def urlOptions = "useUnicode=true&characterEncoding=UTF-8&connectTimeout=500&socketTimeout=500"
 }

--- a/src/main/scala/com/twitter/querulous/database/Database.scala
+++ b/src/main/scala/com/twitter/querulous/database/Database.scala
@@ -34,8 +34,13 @@ object DatabaseFactory {
 }
 
 trait DatabaseFactory {
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String): Database
-  def apply(dbhosts: List[String], username: String, password: String): Database
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String): Database
+
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String): Database =
+    apply(dbhosts, dbname, username, password, null)
+
+  def apply(dbhosts: List[String], username: String, password: String): Database =
+    apply(dbhosts, null, username, password, null)
 }
 
 trait Database {
@@ -52,10 +57,9 @@ trait Database {
     }
   }
 
-  protected def url(dbhosts: List[String], dbname: String) = {
+  protected def url(dbhosts: List[String], dbname: String, urlOptions: String) = {
     val dbnameSegment = if (dbname == null) "" else ("/" + dbname)
-    "jdbc:mysql://" + dbhosts.mkString(",") + dbnameSegment + "?" + urlOptions
+    val urlOptsSegment = if (urlOptions == null) "" else ("?" + urlOptions)
+    "jdbc:mysql://" + dbhosts.mkString(",") + dbnameSegment + urlOptsSegment
   }
-
-  def urlOptions = "useUnicode=true&characterEncoding=UTF-8&connectTimeout=500&socketTimeout=500"
 }

--- a/src/main/scala/com/twitter/querulous/database/Database.scala
+++ b/src/main/scala/com/twitter/querulous/database/Database.scala
@@ -59,7 +59,12 @@ trait Database {
 
   protected def url(dbhosts: List[String], dbname: String, urlOptions: Map[String, String]) = {
     val dbnameSegment = if (dbname == null) "" else ("/" + dbname)
-    val urlOptsSegment = if (urlOptions == null) "" else ("?" + urlOptions.keys.map( k => k + "=" + urlOptions(k) ).mkString("&"))
+    val urlOptsSegment = if (urlOptions == null) {
+      "?useUnicode=true&characterEncoding=UTF-8"
+    } else {
+      "?" + urlOptions.keys.map( k => k + "=" + urlOptions(k) ).mkString("&")
+    }
+
     "jdbc:mysql://" + dbhosts.mkString(",") + dbnameSegment + urlOptsSegment
   }
 }

--- a/src/main/scala/com/twitter/querulous/database/Database.scala
+++ b/src/main/scala/com/twitter/querulous/database/Database.scala
@@ -34,7 +34,7 @@ object DatabaseFactory {
 }
 
 trait DatabaseFactory {
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String): Database
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: Map[String, String]): Database
 
   def apply(dbhosts: List[String], dbname: String, username: String, password: String): Database =
     apply(dbhosts, dbname, username, password, null)
@@ -57,9 +57,9 @@ trait Database {
     }
   }
 
-  protected def url(dbhosts: List[String], dbname: String, urlOptions: String) = {
+  protected def url(dbhosts: List[String], dbname: String, urlOptions: Map[String, String]) = {
     val dbnameSegment = if (dbname == null) "" else ("/" + dbname)
-    val urlOptsSegment = if (urlOptions == null) "" else ("?" + urlOptions)
+    val urlOptsSegment = if (urlOptions == null) "" else ("?" + urlOptions.keys.map( k => k + "=" + urlOptions(k) ).mkString("&"))
     "jdbc:mysql://" + dbhosts.mkString(",") + dbnameSegment + urlOptsSegment
   }
 }

--- a/src/main/scala/com/twitter/querulous/database/MemoizingDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/MemoizingDatabase.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable
 class MemoizingDatabaseFactory(databaseFactory: DatabaseFactory) extends DatabaseFactory {
   private val databases = new mutable.HashMap[String, Database] with mutable.SynchronizedMap[String, Database]
 
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = synchronized {
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: Map[String, String]) = synchronized {
     databases.getOrElseUpdate(
       dbhosts.first + "/" + dbname,
       databaseFactory(dbhosts, dbname, username, password, urlOptions))

--- a/src/main/scala/com/twitter/querulous/database/MemoizingDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/MemoizingDatabase.scala
@@ -5,11 +5,12 @@ import scala.collection.mutable
 class MemoizingDatabaseFactory(databaseFactory: DatabaseFactory) extends DatabaseFactory {
   private val databases = new mutable.HashMap[String, Database] with mutable.SynchronizedMap[String, Database]
 
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String) = synchronized {
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = synchronized {
     databases.getOrElseUpdate(
       dbhosts.first + "/" + dbname,
-      databaseFactory(dbhosts, dbname, username, password))
+      databaseFactory(dbhosts, dbname, username, password, urlOptions))
   }
 
-  def apply(dbhosts: List[String], username: String, password: String) = databaseFactory(dbhosts, username, password)
+  // cannot memoize a connection without specifying a database
+  override def apply(dbhosts: List[String], username: String, password: String) = databaseFactory(dbhosts, username, password)
 }

--- a/src/main/scala/com/twitter/querulous/database/SingleConnectionDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/SingleConnectionDatabase.scala
@@ -5,12 +5,12 @@ import java.sql.{SQLException, Connection}
 
 
 class SingleConnectionDatabaseFactory extends DatabaseFactory {
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = {
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: Map[String, String]) = {
     new SingleConnectionDatabase(dbhosts, dbname, username, password, urlOptions)
   }
 }
 
-class SingleConnectionDatabase(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String)
+class SingleConnectionDatabase(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: Map[String, String])
   extends Database {
   Class.forName("com.mysql.jdbc.Driver")
   private val connectionFactory = new DriverManagerConnectionFactory(url(dbhosts, dbname, urlOptions), username, password)

--- a/src/main/scala/com/twitter/querulous/database/SingleConnectionDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/SingleConnectionDatabase.scala
@@ -5,16 +5,15 @@ import java.sql.{SQLException, Connection}
 
 
 class SingleConnectionDatabaseFactory extends DatabaseFactory {
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String) = {
-    new SingleConnectionDatabase(dbhosts, dbname, username, password)
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = {
+    new SingleConnectionDatabase(dbhosts, dbname, username, password, urlOptions)
   }
-  def apply(dbhosts: List[String], username: String, password: String) = apply(dbhosts, null, username, password)
 }
 
-class SingleConnectionDatabase(dbhosts: List[String], dbname: String, username: String, password: String)
+class SingleConnectionDatabase(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String)
   extends Database {
   Class.forName("com.mysql.jdbc.Driver")
-  private val connectionFactory = new DriverManagerConnectionFactory(url(dbhosts, dbname), username, password)
+  private val connectionFactory = new DriverManagerConnectionFactory(url(dbhosts, dbname, urlOptions), username, password)
 
   def close(connection: Connection) {
     try {

--- a/src/main/scala/com/twitter/querulous/database/StatsCollectingDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/StatsCollectingDatabase.scala
@@ -6,7 +6,7 @@ class StatsCollectingDatabaseFactory(
   databaseFactory: DatabaseFactory,
   stats: StatsCollector) extends DatabaseFactory {
 
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = {
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: Map[String, String]) = {
     new StatsCollectingDatabase(databaseFactory(dbhosts, dbname, username, password, urlOptions), stats)
   }
 }

--- a/src/main/scala/com/twitter/querulous/database/StatsCollectingDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/StatsCollectingDatabase.scala
@@ -6,12 +6,8 @@ class StatsCollectingDatabaseFactory(
   databaseFactory: DatabaseFactory,
   stats: StatsCollector) extends DatabaseFactory {
 
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String) = {
-    new StatsCollectingDatabase(databaseFactory(dbhosts, dbname, username, password), stats)
-  }
-
-  def apply(dbhosts: List[String], username: String, password: String) = {
-    new StatsCollectingDatabase(databaseFactory(dbhosts, username, password), stats)
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = {
+    new StatsCollectingDatabase(databaseFactory(dbhosts, dbname, username, password, urlOptions), stats)
   }
 }
 

--- a/src/main/scala/com/twitter/querulous/database/TimingOutDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/TimingOutDatabase.scala
@@ -9,11 +9,11 @@ import net.lag.logging.Logger
 class SqlDatabaseTimeoutException(msg: String) extends SQLException(msg)
 
 class TimingOutDatabaseFactory(databaseFactory: DatabaseFactory, poolSize: Int, queueSize: Int, openTimeout: Duration, initialTimeout: Duration, maxConnections: Int) extends DatabaseFactory {
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String) = {
-    new TimingOutDatabase(databaseFactory(dbhosts, dbname, username, password), dbhosts, dbname, poolSize, queueSize, openTimeout, initialTimeout, maxConnections)
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = {
+    new TimingOutDatabase(databaseFactory(dbhosts, dbname, username, password, urlOptions), dbhosts, dbname, poolSize, queueSize, openTimeout, initialTimeout, maxConnections)
   }
 
-  def apply(dbhosts: List[String], username: String, password: String) = {
+  override def apply(dbhosts: List[String], username: String, password: String) = {
     new TimingOutDatabase(databaseFactory(dbhosts, username, password), dbhosts, "(null)", poolSize, queueSize, openTimeout, initialTimeout, maxConnections)
   }
 }

--- a/src/main/scala/com/twitter/querulous/database/TimingOutDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/TimingOutDatabase.scala
@@ -9,7 +9,7 @@ import net.lag.logging.Logger
 class SqlDatabaseTimeoutException(msg: String) extends SQLException(msg)
 
 class TimingOutDatabaseFactory(databaseFactory: DatabaseFactory, poolSize: Int, queueSize: Int, openTimeout: Duration, initialTimeout: Duration, maxConnections: Int) extends DatabaseFactory {
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = {
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: Map[String, String]) = {
     val dbLabel = if (dbname != null) dbname else "(null)"
 
     new TimingOutDatabase(databaseFactory(dbhosts, dbname, username, password, urlOptions), dbhosts, dbLabel, poolSize, queueSize, openTimeout, initialTimeout, maxConnections)

--- a/src/main/scala/com/twitter/querulous/database/TimingOutDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/TimingOutDatabase.scala
@@ -10,11 +10,9 @@ class SqlDatabaseTimeoutException(msg: String) extends SQLException(msg)
 
 class TimingOutDatabaseFactory(databaseFactory: DatabaseFactory, poolSize: Int, queueSize: Int, openTimeout: Duration, initialTimeout: Duration, maxConnections: Int) extends DatabaseFactory {
   def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = {
-    new TimingOutDatabase(databaseFactory(dbhosts, dbname, username, password, urlOptions), dbhosts, dbname, poolSize, queueSize, openTimeout, initialTimeout, maxConnections)
-  }
+    val dbLabel = if (dbname != null) dbname else "(null)"
 
-  override def apply(dbhosts: List[String], username: String, password: String) = {
-    new TimingOutDatabase(databaseFactory(dbhosts, username, password), dbhosts, "(null)", poolSize, queueSize, openTimeout, initialTimeout, maxConnections)
+    new TimingOutDatabase(databaseFactory(dbhosts, dbname, username, password, urlOptions), dbhosts, dbLabel, poolSize, queueSize, openTimeout, initialTimeout, maxConnections)
   }
 }
 

--- a/src/main/scala/com/twitter/querulous/evaluator/AutoDisablingQueryEvaluator.scala
+++ b/src/main/scala/com/twitter/querulous/evaluator/AutoDisablingQueryEvaluator.scala
@@ -27,10 +27,10 @@ class AutoDisablingQueryEvaluatorFactory(
   }
 }
 
-class AutoDisablingQueryEvaluator(
+class AutoDisablingQueryEvaluator (
   queryEvaluator: QueryEvaluator,
-  disableErrorCount: Int,
-  disableDuration: Duration) extends QueryEvaluatorProxy(queryEvaluator) {
+  protected val disableErrorCount: Int,
+  protected val disableDuration: Duration) extends QueryEvaluatorProxy(queryEvaluator) with AutoDisabler {
 
   private var disabledUntil: Time = Time.never
   private var consecutiveErrors = 0
@@ -56,24 +56,4 @@ class AutoDisablingQueryEvaluator(
     }
   }
 
-  private def noteOperationOutcome(success: Boolean) {
-    synchronized {
-      if (success) {
-        consecutiveErrors = 0
-      } else {
-        consecutiveErrors += 1
-        if (consecutiveErrors >= disableErrorCount) {
-          disabledUntil = disableDuration.fromNow
-        }
-      }
-    }
-  }
-
-  private def throwIfDisabled() {
-    synchronized {
-      if (Time.now < disabledUntil) {
-        throw new SQLException("Server is temporarily disabled")
-      }
-    }
-  }
 }

--- a/src/main/scala/com/twitter/querulous/evaluator/AutoDisablingQueryEvaluator.scala
+++ b/src/main/scala/com/twitter/querulous/evaluator/AutoDisablingQueryEvaluator.scala
@@ -18,7 +18,7 @@ class AutoDisablingQueryEvaluatorFactory(
       disableDuration)
   }
 
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = {
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: Map[String, String]) = {
     chainEvaluator(queryEvaluatorFactory(dbhosts, dbname, username, password, urlOptions))
   }
 }

--- a/src/main/scala/com/twitter/querulous/evaluator/AutoDisablingQueryEvaluator.scala
+++ b/src/main/scala/com/twitter/querulous/evaluator/AutoDisablingQueryEvaluator.scala
@@ -18,12 +18,8 @@ class AutoDisablingQueryEvaluatorFactory(
       disableDuration)
   }
 
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String) = {
-    chainEvaluator(queryEvaluatorFactory(dbhosts, dbname, username, password))
-  }
-
-  def apply(dbhosts: List[String], username: String, password: String) = {
-    chainEvaluator(queryEvaluatorFactory(dbhosts, username, password))
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = {
+    chainEvaluator(queryEvaluatorFactory(dbhosts, dbname, username, password, urlOptions))
   }
 }
 

--- a/src/main/scala/com/twitter/querulous/evaluator/QueryEvaluator.scala
+++ b/src/main/scala/com/twitter/querulous/evaluator/QueryEvaluator.scala
@@ -32,15 +32,15 @@ object QueryEvaluator extends QueryEvaluatorFactory {
     new StandardQueryEvaluatorFactory(databaseFactory, queryFactory)
   }
 
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = {
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: Map[String, String]) = {
     createEvaluatorFactory()(dbhosts, dbname, username, password, urlOptions)
   }
 }
 
 trait QueryEvaluatorFactory {
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String): QueryEvaluator
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: Map[String, String]): QueryEvaluator
 
-  def apply(dbhost: String, dbname: String, username: String, password: String, urlOptions: String): QueryEvaluator = {
+  def apply(dbhost: String, dbname: String, username: String, password: String, urlOptions: Map[String, String]): QueryEvaluator = {
     apply(List(dbhost), dbname, username, password, urlOptions)
   }
 
@@ -63,10 +63,11 @@ trait QueryEvaluatorFactory {
  def apply(config: ConfigMap): QueryEvaluator = {
     apply(
       config.getList("hostname").toList,
-      config("database"),
+      config.getString("database").getOrElse(null),
       config("username"),
-      config("password"),
-      config.getString("url_options").getOrElse(null)
+      config.getString("password").getOrElse(null),
+      // this is so lame, why do I have to cast this back?
+      config.getConfigMap("url_options").map(_.asMap.asInstanceOf[Map[String, String]]).getOrElse(null)
     )
   }
 }

--- a/src/main/scala/com/twitter/querulous/evaluator/QueryEvaluator.scala
+++ b/src/main/scala/com/twitter/querulous/evaluator/QueryEvaluator.scala
@@ -32,24 +32,42 @@ object QueryEvaluator extends QueryEvaluatorFactory {
     new StandardQueryEvaluatorFactory(databaseFactory, queryFactory)
   }
 
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String) = {
-    createEvaluatorFactory()(dbhosts, dbname, username, password)
-  }
-
-  def apply(dbhosts: List[String], username: String, password: String) = {
-    createEvaluatorFactory()(dbhosts, username, password)
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = {
+    createEvaluatorFactory()(dbhosts, dbname, username, password, urlOptions)
   }
 }
 
 trait QueryEvaluatorFactory {
-  def apply(dbhost: String, dbname: String, username: String, password: String): QueryEvaluator = {
-    apply(List(dbhost), dbname, username, password)
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String): QueryEvaluator
+
+  def apply(dbhost: String, dbname: String, username: String, password: String, urlOptions: String): QueryEvaluator = {
+    apply(List(dbhost), dbname, username, password, urlOptions)
   }
-  def apply(dbhost: String, username: String, password: String): QueryEvaluator = apply(List(dbhost), username, password)
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String): QueryEvaluator
-  def apply(dbhosts: List[String], username: String, password: String): QueryEvaluator
-  def apply(config: ConfigMap): QueryEvaluator = {
-    apply(config.getList("hostname").toList, config("database"), config("username"), config("password"))
+
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String): QueryEvaluator = {
+    apply(dbhosts, dbname, username, password, null)
+  }
+
+  def apply(dbhost: String, dbname: String, username: String, password: String): QueryEvaluator = {
+    apply(List(dbhost), dbname, username, password, null)
+  }
+
+  def apply(dbhost: String, username: String, password: String): QueryEvaluator = {
+    apply(List(dbhost), null, username, password, null)
+  }
+
+  def apply(dbhosts: List[String], username: String, password: String): QueryEvaluator = {
+    apply(dbhosts, null, username, password, null)
+  }
+
+ def apply(config: ConfigMap): QueryEvaluator = {
+    apply(
+      config.getList("hostname").toList,
+      config("database"),
+      config("username"),
+      config("password"),
+      config.getString("url_options").getOrElse(null)
+    )
   }
 }
 

--- a/src/main/scala/com/twitter/querulous/evaluator/StandardQueryEvaluator.scala
+++ b/src/main/scala/com/twitter/querulous/evaluator/StandardQueryEvaluator.scala
@@ -10,13 +10,8 @@ class StandardQueryEvaluatorFactory(
   databaseFactory: DatabaseFactory,
   queryFactory: QueryFactory) extends QueryEvaluatorFactory {
 
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String) = {
-    val database = databaseFactory(dbhosts, dbname, username, password)
-    new StandardQueryEvaluator(database, queryFactory)
-  }
-
-  def apply(dbhosts: List[String], username: String, password: String) = {
-    val database = databaseFactory(dbhosts, username, password)
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = {
+    val database = databaseFactory(dbhosts, dbname, username, password, urlOptions)
     new StandardQueryEvaluator(database, queryFactory)
   }
 }

--- a/src/main/scala/com/twitter/querulous/evaluator/StandardQueryEvaluator.scala
+++ b/src/main/scala/com/twitter/querulous/evaluator/StandardQueryEvaluator.scala
@@ -10,7 +10,7 @@ class StandardQueryEvaluatorFactory(
   databaseFactory: DatabaseFactory,
   queryFactory: QueryFactory) extends QueryEvaluatorFactory {
 
-  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: String) = {
+  def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: Map[String, String]) = {
     val database = databaseFactory(dbhosts, dbname, username, password, urlOptions)
     new StandardQueryEvaluator(database, queryFactory)
   }

--- a/src/test/scala/com/twitter/querulous/integration/QuerySpec.scala
+++ b/src/test/scala/com/twitter/querulous/integration/QuerySpec.scala
@@ -14,12 +14,9 @@ class QuerySpec extends Specification {
 
   import TestEvaluator._
   val config = Configgy.config.configMap("db")
-  val username = config("username")
-  val password = config("password")
-  val urlOptions = config("url_options")
 
   "Query" should {
-    val queryEvaluator = testEvaluatorFactory("localhost", null, username, password, urlOptions)
+    val queryEvaluator = testEvaluatorFactory(config)
 
     "with too many arguments" >> {
       queryEvaluator.select("SELECT 1 FROM DUAL WHERE 1 IN (?)", 1, 2, 3) { r => 1 } must throwA[TooManyQueryParametersException]
@@ -34,10 +31,10 @@ class QuerySpec extends Specification {
     }
 
     "be backwards compatible" >> {
-      val noOpts = testEvaluatorFactory("localhost", null, username, password)
+      val noOpts = testEvaluatorFactory("localhost", null, config("username"), config("password"))
       noOpts.select("SELECT 1 FROM DUAL WHERE 1 IN (?)", List(1, 2, 3))(_.getInt(1)).toList mustEqual List(1)
 
-      val noDBNameOrOpts = testEvaluatorFactory("localhost", username, password)
+      val noDBNameOrOpts = testEvaluatorFactory("localhost", config("username"), config("password"))
       noDBNameOrOpts.select("SELECT 1 FROM DUAL WHERE 1 IN (?)", List(1, 2, 3))(_.getInt(1)).toList mustEqual List(1)
     }
   }

--- a/src/test/scala/com/twitter/querulous/integration/QuerySpec.scala
+++ b/src/test/scala/com/twitter/querulous/integration/QuerySpec.scala
@@ -16,9 +16,10 @@ class QuerySpec extends Specification {
   val config = Configgy.config.configMap("db")
   val username = config("username")
   val password = config("password")
+  val urlOptions = config("url_options")
 
   "Query" should {
-    val queryEvaluator = testEvaluatorFactory("localhost", username, password)
+    val queryEvaluator = testEvaluatorFactory("localhost", username, password, urlOptions)
 
     "with too many arguments" >> {
       queryEvaluator.select("SELECT 1 FROM DUAL WHERE 1 IN (?)", 1, 2, 3) { r => 1 } must throwA[TooManyQueryParametersException]

--- a/src/test/scala/com/twitter/querulous/integration/QuerySpec.scala
+++ b/src/test/scala/com/twitter/querulous/integration/QuerySpec.scala
@@ -19,7 +19,7 @@ class QuerySpec extends Specification {
   val urlOptions = config("url_options")
 
   "Query" should {
-    val queryEvaluator = testEvaluatorFactory("localhost", username, password, urlOptions)
+    val queryEvaluator = testEvaluatorFactory("localhost", null, username, password, urlOptions)
 
     "with too many arguments" >> {
       queryEvaluator.select("SELECT 1 FROM DUAL WHERE 1 IN (?)", 1, 2, 3) { r => 1 } must throwA[TooManyQueryParametersException]
@@ -31,6 +31,14 @@ class QuerySpec extends Specification {
 
     "with just the right number of arguments" >> {
       queryEvaluator.select("SELECT 1 FROM DUAL WHERE 1 IN (?)", List(1, 2, 3))(_.getInt(1)).toList mustEqual List(1)
+    }
+
+    "be backwards compatible" >> {
+      val noOpts = testEvaluatorFactory("localhost", null, username, password)
+      noOpts.select("SELECT 1 FROM DUAL WHERE 1 IN (?)", List(1, 2, 3))(_.getInt(1)).toList mustEqual List(1)
+
+      val noDBNameOrOpts = testEvaluatorFactory("localhost", username, password)
+      noDBNameOrOpts.select("SELECT 1 FROM DUAL WHERE 1 IN (?)", List(1, 2, 3))(_.getInt(1)).toList mustEqual List(1)
     }
   }
 }

--- a/src/test/scala/com/twitter/querulous/unit/MemoizingDatabaseFactorySpec.scala
+++ b/src/test/scala/com/twitter/querulous/unit/MemoizingDatabaseFactorySpec.scala
@@ -18,8 +18,8 @@ class MemoizingDatabaseFactorySpec extends Specification with JMocker {
       val memoizingDatabase = new MemoizingDatabaseFactory(databaseFactory)
 
       expect {
-        one(databaseFactory).apply(hosts, "bar", username, password) willReturn database1
-        one(databaseFactory).apply(hosts, "baz", username, password) willReturn database2
+        one(databaseFactory).apply(hosts, "bar", username, password, null) willReturn database1
+        one(databaseFactory).apply(hosts, "baz", username, password, null) willReturn database2
       }
       memoizingDatabase(hosts, "bar", username, password) mustBe database1
       memoizingDatabase(hosts, "bar", username, password) mustBe database1

--- a/src/test/scala/com/twitter/querulous/unit/QueryEvaluatorSpec.scala
+++ b/src/test/scala/com/twitter/querulous/unit/QueryEvaluatorSpec.scala
@@ -21,7 +21,7 @@ class QueryEvaluatorSpec extends Specification with JMocker with ClassMocker {
   val config = Configgy.config.configMap("db")
   val username = config("username")
   val password = config("password")
-  val urlOptions = config("url_options")
+  val urlOptions = config("url_options").asInstanceOf[Map[String, String]]
 
   "QueryEvaluator" should {
     val queryEvaluator = testEvaluatorFactory("localhost", "db_test", username, password, urlOptions)

--- a/src/test/scala/com/twitter/querulous/unit/QueryEvaluatorSpec.scala
+++ b/src/test/scala/com/twitter/querulous/unit/QueryEvaluatorSpec.scala
@@ -21,10 +21,11 @@ class QueryEvaluatorSpec extends Specification with JMocker with ClassMocker {
   val config = Configgy.config.configMap("db")
   val username = config("username")
   val password = config("password")
+  val urlOptions = config("url_options")
 
   "QueryEvaluator" should {
-    val queryEvaluator = testEvaluatorFactory("localhost", "db_test", username, password)
-    val rootQueryEvaluator = testEvaluatorFactory("localhost", null, username, password)
+    val queryEvaluator = testEvaluatorFactory("localhost", "db_test", username, password, urlOptions)
+    val rootQueryEvaluator = testEvaluatorFactory("localhost", null, username, password, urlOptions)
     val queryFactory = new SqlQueryFactory
 
     doBefore {

--- a/src/test/scala/com/twitter/querulous/unit/QueryEvaluatorSpec.scala
+++ b/src/test/scala/com/twitter/querulous/unit/QueryEvaluatorSpec.scala
@@ -21,7 +21,7 @@ class QueryEvaluatorSpec extends Specification with JMocker with ClassMocker {
   val config = Configgy.config.configMap("db")
   val username = config("username")
   val password = config("password")
-  val urlOptions = config("url_options").asInstanceOf[Map[String, String]]
+  val urlOptions = config.configMap("url_options").asMap.asInstanceOf[Map[String, String]]
 
   "QueryEvaluator" should {
     val queryEvaluator = testEvaluatorFactory("localhost", "db_test", username, password, urlOptions)


### PR DESCRIPTION
This was a bit more invasive than intended, but I don't know how to get around it. Also pulls in ed's auto-disabler work. note one of the consequences of this change is that we do not default to unicode. it must be supplied as part of the url opts. we can add this back as part of the defaults if desired...
